### PR TITLE
feat: check version when app starts

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -189,6 +189,8 @@ func main() {
 		return
 	}
 
+	core.CheckForUpdates()
+
 	// 1. Load the config file (bootstrap for db-path and initial settings)
 	loadConfig()
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -71,6 +71,8 @@ const formatBytes = (bytes: number) => {
 export default function SettingsPage() {
   const [sysConfig, setSysConfig] = useState<SysConfig | null>(null);
   const [appVersion, setAppVersion] = useState<string>("");
+  const [latestVersion, setLatestVersion] = useState<string>("");
+  const [latestVersionTag, setLatestVersionTag] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,6 +90,8 @@ export default function SettingsPage() {
         ]);
         setSysConfig(configRes.data);
         setAppVersion(versionRes.data.version);
+        setLatestVersion(versionRes.data.latest_version);
+        setLatestVersionTag(versionRes.data.latest_version_tag);
         setLogLevel(configRes.data.log_level);
         setApiAddr(configRes.data.api_addr);
         setMaxSessionsRetain(
@@ -167,6 +171,35 @@ export default function SettingsPage() {
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           )}
+
+          {appVersion &&
+            latestVersion &&
+            appVersion !== "dev" &&
+            appVersion.replace(/^v/, "") !==
+              latestVersion.replace(/^v/, "") && (
+              <Alert className="border-yellow-500/50 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
+                <Network className="h-4 w-4" />
+                <AlertDescription className="flex items-center justify-between w-full">
+                  <span>
+                    A new version of Inspect HTTP Proxy Plus is available:{" "}
+                    <strong>{latestVersionTag}</strong>
+                  </span>
+                  <Button
+                    variant="link"
+                    className="h-auto p-0 text-yellow-600 dark:text-yellow-400 font-bold"
+                    asChild
+                  >
+                    <a
+                      href="https://github.com/liyu1981/inspect-http-proxy-plus/releases/latest"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Download Latest
+                    </a>
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
 
           {!loading && !error && sysConfig && (
             <Tabs

--- a/pkg/core/global.go
+++ b/pkg/core/global.go
@@ -12,6 +12,8 @@ type GlobalVarStore struct {
 	config_ids        []string
 	id_to_config      map[string]*ProxyConfig
 	id_to_proxyserver map[string]*http.Server
+	latestVersion     string
+	latestVersionTag  string
 }
 
 // GlobalVar is the shared instance of the configuration store.
@@ -251,4 +253,23 @@ func (g *GlobalVarStore) ClearProxyServers() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.id_to_proxyserver = make(map[string]*http.Server)
+}
+
+// ====================
+// Version Methods
+// ====================
+
+// SetLatestVersion stores the latest version information.
+func (g *GlobalVarStore) SetLatestVersion(version, tag string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.latestVersion = version
+	g.latestVersionTag = tag
+}
+
+// GetLatestVersion returns the stored latest version and its tag.
+func (g *GlobalVarStore) GetLatestVersion() (string, string) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.latestVersion, g.latestVersionTag
 }

--- a/pkg/core/version_check.go
+++ b/pkg/core/version_check.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type GitHubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// CheckForUpdates fetches the latest release from GitHub and compares it with the current version.
+// If a newer version is available, it returns the tag name of the latest release.
+func CheckForUpdates() {
+	go func() {
+		// Give some time for the server to start and print its initial messages
+		time.Sleep(2 * time.Second)
+
+		client := &http.Client{
+			Timeout: 5 * time.Second,
+		}
+
+		resp, err := client.Get("https://api.github.com/repos/liyu1981/inspect-http-proxy-plus/releases/latest")
+		if err != nil {
+			log.Debug().Err(err).Msg("Failed to check for updates from GitHub")
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			log.Debug().Str("status", resp.Status).Msg("GitHub API returned non-OK status when checking for updates")
+			return
+		}
+
+		var release GitHubRelease
+		if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+			log.Debug().Err(err).Msg("Failed to decode GitHub release JSON")
+			return
+		}
+
+		latestVersion := strings.TrimPrefix(release.TagName, "v")
+		currentVersion := strings.TrimPrefix(Version, "v")
+
+		GlobalVar.SetLatestVersion(latestVersion, release.TagName)
+
+		if Version != "dev" && latestVersion != currentVersion {
+			fmt.Printf("\n%sNew version available: %s%s\n", ColorYellow, release.TagName, ColorReset)
+			fmt.Printf("Download it from: https://github.com/liyu1981/inspect-http-proxy-plus/releases/latest\n\n")
+		}
+	}()
+}

--- a/pkg/web/api/api_version.go
+++ b/pkg/web/api/api_version.go
@@ -13,7 +13,11 @@ func (h *ApiHandler) handleVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	latestVersion, latestVersionTag := core.GlobalVar.GetLatestVersion()
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"version": core.Version,
+		"version":            core.Version,
+		"latest_version":     latestVersion,
+		"latest_version_tag": latestVersionTag,
 	})
 }

--- a/pkg/web/api/api_version_test.go
+++ b/pkg/web/api/api_version_test.go
@@ -25,4 +25,12 @@ func TestHandleVersion(t *testing.T) {
 	if result["version"] != core.Version {
 		t.Errorf("Expected version %s, got %s", core.Version, result["version"])
 	}
+
+	// It should also contain latest_version and latest_version_tag (even if empty)
+	if _, exists := result["latest_version"]; !exists {
+		t.Errorf("Expected latest_version to exist in response")
+	}
+	if _, exists := result["latest_version_tag"]; !exists {
+		t.Errorf("Expected latest_version_tag to exist in response")
+	}
 }


### PR DESCRIPTION
Summary of changes:
   1. Created pkg/core/version_check.go which fetches the latest release from the GitHub API in a background goroutine on startup.
   2. Updated GlobalVarStore in pkg/core/global.go to store the latest version information.
   3. Modified cmd/proxy/main.go to call the version check upon starting.
   4. Updated the /api/version endpoint in pkg/web/api/api_version.go to return the latest available version and its tag.
   5. Updated frontend/src/app/settings/page.tsx to display a notification alert when a new version is detected (and the current version is not "dev").
   6. Updated pkg/web/api/api_version_test.go to verify the new API fields.

#18 